### PR TITLE
Fixed issue when  'getViewportSize' is zero

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -9,6 +9,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
   private rowHeight!: number;
   private headerHeight!: number;
   private bufferMultiplier!: number;
+  private tableHeight!: number;
   private indexChange = new Subject<number>();
   public stickyChange = new Subject<number>();
 
@@ -62,13 +63,16 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     // no-op
   }
 
-  public setConfig({rowHeight, headerHeight, bufferMultiplier}: { rowHeight: number, headerHeight: number, bufferMultiplier: number }) {
-    if (this.rowHeight === rowHeight || this.headerHeight === headerHeight || this.bufferMultiplier === bufferMultiplier) {
+  public setConfig({rowHeight, headerHeight, bufferMultiplier, tableHeight}: { rowHeight: number, headerHeight: number, 
+    bufferMultiplier: number, tableHeight: number }) {
+    if (this.rowHeight === rowHeight || this.headerHeight === headerHeight ||
+      this.bufferMultiplier === bufferMultiplier || this.tableHeight === tableHeight) {
       return;
     }
     this.rowHeight = rowHeight;
     this.headerHeight = headerHeight;
     this.bufferMultiplier = bufferMultiplier;
+    this.tableHeight = tableHeight;
     this.updateContent();
   }
 
@@ -77,7 +81,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
       return;
     }
     const scrollOffset = this.viewport.measureScrollOffset();
-    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
+    const amount = Math.ceil(this.calculateProperViewPortSize() / this.rowHeight);
     const offset = Math.max(scrollOffset - this.headerHeight, 0);
     const buffer = Math.ceil(amount * this.bufferMultiplier);
 
@@ -90,5 +94,19 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     this.viewport.setRenderedRange({start, end});
     this.indexChange.next(index);
     this.stickyChange.next(renderedOffset);
+  }
+
+  private calculateProperViewPortSize(): number {
+    const valueViewPortSize = this.viewport.getViewportSize();
+
+    if (valueViewPortSize > 0) {
+      return valueViewPortSize;
+    }
+
+    if (this.tableHeight === 0) {
+      return this.rowHeight * 3;
+    }
+
+    return this.tableHeight;
   }
 }

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -14,7 +14,8 @@ export function _tableVirtualScrollDirectiveStrategyFactory(tableDir: TableItemS
 const defaults = {
   rowHeight: 48,
   headerHeight: 56,
-  bufferMultiplier: 0.7
+  bufferMultiplier: 0.7,
+  tableHeight: 0
 };
 
 @Directive({
@@ -37,6 +38,9 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
 
   @Input()
   bufferMultiplier = defaults.bufferMultiplier;
+
+  @Input()
+  tableHeight = defaults.tableHeight;
 
   @ContentChild(MatTable, {static: true})
   table: MatTable<any>;
@@ -114,7 +118,8 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
     const config = {
       rowHeight: +this.rowHeight || defaults.rowHeight,
       headerHeight: +this.headerHeight || defaults.headerHeight,
-      bufferMultiplier: +this.bufferMultiplier || defaults.bufferMultiplier
+      bufferMultiplier: +this.bufferMultiplier || defaults.bufferMultiplier,
+      tableHeight: +this.tableHeight || defaults.tableHeight
     };
     this.scrollStrategy.setConfig(config);
   }


### PR DESCRIPTION
The issue is when the method: 'this.viewport.getViewportSize()' return zero then other calcualtions always sets up 'start' and 'end' on that same values i.e start = 1 and end =1 or start = 4 and end =4. Then when we calculate new array to dispaly rows the method '_updateChangeSubscription()' has internal method 'data.slice(start,end)' who is always returns empty array.