### PR TITLE
Set "streamsReady" to true after init

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -49,6 +49,7 @@ export class TableVirtualScrollDataSource<T> extends MatTableDataSource<T> {
     if (!this.streamsReady) {
       this.dataToRender$ = new ReplaySubject<T[]>(1);
       this.dataOfRange$ = new ReplaySubject<T[]>(1);
+      this.streamsReady = true;
     }
   }
 }


### PR DESCRIPTION
The streamsReady field has to be set to true after initialization because in a weird edge case it resulted in a bug so that the sort would not work at all because `dataToRender$.next(data)` (line 41) didn't cause the desired emitting of the data in the `TableItemSizeDirective` in the connectDataSource method.