### PR TITLE
[bugfix] scroll with 2 sticky headers

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -151,7 +151,7 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
         if (this.stickyPositions.has(parent)) {
           baseOffset = this.stickyPositions.get(parent);
         }
-        el.style.top = `-${-baseOffset + offset}px`;
+        el.style.top = `${baseOffset - offset}px`;
       });
     this.scrollStrategy.viewport.elementRef.nativeElement.querySelectorAll(stickyFooterSelector)
       .forEach((el: HTMLElement) => {


### PR DESCRIPTION
There is a visual bug when you have 2 sticky headers.
It's fine until you go until you go past the 1st buffer. When you scroll back to the initial top, the 2nd header goes before the table.