### PR TITLE
fix(table-data-source): check if _renderChangesSubscription is null

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -35,7 +35,7 @@ export class TableVirtualScrollDataSource<T> extends MatTableDataSource<T> {
     const paginatedData = combineLatest([orderedData, pageChange])
       .pipe(map(([data]) => this._pageData(data)));
 
-    this._renderChangesSubscription.unsubscribe();
+    this._renderChangesSubscription?.unsubscribe();
     this._renderChangesSubscription = new Subscription();
     this._renderChangesSubscription.add(
       paginatedData.subscribe(data => this.dataToRender$.next(data))


### PR DESCRIPTION
Angular Material changed the initial value of _renderChangesSubscription from `Subscription.EMPTY` to `null`

See https://github.com/angular/components/commit/6d36942510722799f6c6822e96326c490f33b5f7#diff-278da9b69632db3b3a5a49aadacf54369112aecad67153f27f62f506df79e6e0

Fixes: #55 