### PR TITLE
Remove duplicate observers to improve performance

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -111,7 +111,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     const skip = Math.round(offset / this.rowHeight);
     const index = Math.max(0, skip);
-    const start = 0; //Math.min(0, index - buffer);
+    const start = Math.min(0, index - buffer);
     const end = Math.min(this.dataLength, index + amount + buffer);
     const renderedOffset = start * this.rowHeight;
     if (start !== this._start || end !== this._end) {

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -111,7 +111,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     const skip = Math.round(offset / this.rowHeight);
     const index = Math.max(0, skip);
-    const start = Math.min(0, index - buffer);
+    const start = Math.max(0, index - buffer);
     const end = Math.min(this.dataLength, index + amount + buffer);
     const renderedOffset = start * this.rowHeight;
     if (start !== this._start || end !== this._end) {

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -41,7 +41,8 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
   public attach(viewport: CdkVirtualScrollViewport): void {
     this.viewport = viewport;
-    // did know why, there are two observers. And that will cause TableItemSizeDirective::connectDataSource receive two notification for one date changes.
+    // did know why, there are two observers. And that will cause 
+    // TableItemSizeDirective::connectDataSource receive two notification for one date changes.
     // for big and complex mat-table, that will slow down performance.
     // check the observers here to make sure only one observer exist.
     if (this.renderedRangeStream.observers.length > 0) {

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -41,7 +41,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
   public attach(viewport: CdkVirtualScrollViewport): void {
     this.viewport = viewport;
-    // did know why, there are two observers. And that will cause 
+    // did know why, there are two observers. And that will cause
     // TableItemSizeDirective::connectDataSource receive two notification for one date changes.
     // for big and complex mat-table, that will slow down performance.
     // check the observers here to make sure only one observer exist.


### PR DESCRIPTION
Hi diprokon,

Your project helps us a lot. 
Recently, we create a big and very complex table, but encounter performance issue when you scroll up and down.

Then I print some log and find that there are two identical observers. And they will send two same notification when renderData changed.

Remove one of them could help to improve performance.

Please review the PR. Let me know if you have better solution. Thank you!