### PR TITLE
ScrollingFix: Changing scroll detection algorithm to use relative scroll distances

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -102,6 +102,8 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     const buffer = Math.ceil(amount * this.bufferMultiplier);
     const end = start + amount + buffer;
 
+    console.log(`Initial offset and range ${JSON.stringify({renderedOffset, start, end})}`);
+
 
     const lowerBuffer = Math.min(buffer, start);
     const bufferOffset = renderedOffset + lowerBuffer * this.rowHeight;
@@ -113,6 +115,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     // Only bother updating the displayed information if we've scrolled more than a row
     const rowSensitivity = 1.0;
+    console.log(`Rows scrolled: ${rowsScrolled}`);
     if (Math.abs(rowsScrolled) < rowSensitivity) {
       this.viewport.setRenderedContentOffset(renderedOffset);
       this.viewport.setRenderedRange({start, end});
@@ -120,7 +123,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     }
 
     const rowsToMove = Math.sign(rowsScrolled) * Math.floor(Math.abs(rowsScrolled));
-    const adjustedRenderedOffset = renderedOffset + rowsToMove * this.rowHeight;
+    const adjustedRenderedOffset = Math.max(0, renderedOffset + rowsToMove * this.rowHeight);
     this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
 
     const adjustedStart = Math.max(0, start + rowsToMove);
@@ -129,5 +132,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
 
     this.indexChange.next(adjustedStart - lowerBuffer);
     this.stickyChange.next(adjustedRenderedOffset);
+    console.log(`Setting offset and range ${JSON.stringify({adjustedRenderedOffset, adjustedStart, adjustedEnd})}`)
+
   }
 }

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -135,7 +135,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
 
     const adjustedStart = Math.max(0, start + rowsToMove);
-    const adjustedEnd = adjustedStart + itemsDisplayed + bufferItems;
+    const adjustedEnd = adjustedStart + itemsDisplayed + 2 * bufferItems;
     this.viewport.setRenderedRange({start: adjustedStart, end: adjustedEnd});
 
     this.stickyChange.next(adjustedRenderedOffset);

--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -61,7 +61,6 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
   }
 
   public onContentRendered(): void {
-    // no-op
   }
 
   public onRenderedOffsetChanged(): void {
@@ -96,19 +95,39 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
     if (!this.viewport || !this.rowHeight) {
       return;
     }
-    const scrollOffset = this.viewport.measureScrollOffset();
-    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
-    const offset = Math.max(scrollOffset - this.headerHeight, 0);
-    const buffer = Math.ceil(amount * this.bufferMultiplier);
 
-    const skip = Math.round(offset / this.rowHeight);
-    const index = Math.max(0, skip);
-    const start = Math.max(0, index - buffer);
-    const end = Math.min(this.dataLength, index + amount + buffer);
-    const renderedOffset = start * this.rowHeight;
-    this.viewport.setRenderedContentOffset(renderedOffset);
-    this.viewport.setRenderedRange({start, end});
-    this.indexChange.next(index);
-    this.stickyChange.next(renderedOffset);
+    const renderedOffset = this.viewport.getOffsetToRenderedContentStart();
+    const start = renderedOffset / this.rowHeight;
+    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
+    const buffer = Math.ceil(amount * this.bufferMultiplier);
+    const end = start + amount + buffer;
+
+
+    const lowerBuffer = Math.min(buffer, start);
+    const bufferOffset = renderedOffset + lowerBuffer * this.rowHeight;
+    const scrollOffset = this.viewport.measureScrollOffset();
+
+    // How far the scroll offset is from the actual start of displayed information
+    const relativeScrollOffset = scrollOffset - bufferOffset;
+    const rowsScrolled = relativeScrollOffset / this.rowHeight;
+
+    // Only bother updating the displayed information if we've scrolled more than a row
+    const rowSensitivity = 1.0;
+    if (Math.abs(rowsScrolled) < rowSensitivity) {
+      this.viewport.setRenderedContentOffset(renderedOffset);
+      this.viewport.setRenderedRange({start, end});
+      return;
+    }
+
+    const rowsToMove = Math.sign(rowsScrolled) * Math.floor(Math.abs(rowsScrolled));
+    const adjustedRenderedOffset = renderedOffset + rowsToMove * this.rowHeight;
+    this.viewport.setRenderedContentOffset(adjustedRenderedOffset);
+
+    const adjustedStart = Math.max(0, start + rowsToMove);
+    const adjustedEnd = adjustedStart + amount + buffer;
+    this.viewport.setRenderedRange({start: adjustedStart, end: adjustedEnd});
+
+    this.indexChange.next(adjustedStart - lowerBuffer);
+    this.stickyChange.next(adjustedRenderedOffset);
   }
 }

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.spec.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.spec.ts
@@ -159,14 +159,14 @@ describe('TableItemSizeDirective', () => {
     const tbody = fixture.nativeElement.querySelector('tbody');
 
     expect(tbody.children.length)
-      .toBe(6, 'should render 6 10px row to fill 40px*(1 + 0.5) space');
+      .toBe(8, 'should render 8 10px row to fill 40px + 40px * 0.5 (buffer before) + 40px * 0.5 (buffer after) space');
   }));
 
   it('get the rendered range', fakeAsync(() => {
     finishInit(fixture);
 
     expect(viewport.getRenderedRange())
-      .toEqual({start: 0, end: 6}, 'should render the first 6 10px items to fill 40px*(1 + 0.5) space');
+      .toEqual({start: 0, end: 8}, 'should render 8 10px row to fill 40px + 40px * 0.5 (buffer before) + 40px * 0.5 (buffer after) space');
   }));
 
   it('should set the correct rendered range on scroll', fakeAsync(() => {
@@ -180,7 +180,7 @@ describe('TableItemSizeDirective', () => {
     flush();
 
     expect(viewport.getRenderedRange())
-      .toEqual({start: 6, end: 14}, 'current index should be 8, buffer = 2');
+      .toEqual({start: 8, end: 16}, 'scrolled ten items down, so items 10-14 should be visible, with items 8-16 rendered in the buffer');
   }));
 
   it('should subscribe and rerender after dataSource is changed', fakeAsync(() => {


### PR DESCRIPTION
~~This is still a slight work in progress due to figuring out a test adjustment + taking care of one more special case. See my WIP note below.~~

This should address the following issues, I think - 
https://github.com/diprokon/ng-table-virtual-scroll/issues/42
https://github.com/diprokon/ng-table-virtual-scroll/issues/58
https://github.com/diprokon/ng-table-virtual-scroll/issues/60

It looks like the algorithm for adjusting the rendered content could get confused when a row moved in or out of view. I couldn't figure out a way to fix this algorithm using absolute `scrollOffsets` and `renderedOffsets`, because the `scrollOffset` would jump at the same time as the `renderedOffset`, which would cause all sorts of problems at the point of the jump.

Instead, I used the observation that we really only need to scroll when the `scrollOffset` moves more than one row of distance. This means that moving the table can be determined by the relative distance between `scrollOffset` and `renderedOffset` instead of the absolute distance.

 ~~**WIP NOTE**~~
* ~~I haven't fixed the failing test yet, I didn't have time today to see whether the test failure is correct or not.~~
* ~~More importantly, there's a special case with sticky headers that I haven't addressed. If you scroll down in a table with sticky headers, then scroll up VERY QUICKLY, you might get stuck with your top row being row 2 or row 3 instead of row 1. There's a few ways to address this; I'll think of a non-hacky way and add it hopefully tomorrow.~~

I finished up the last of the WIP tasks. There's a slight change to the tests because I handle the top of the table slightly differently.