### PR TITLE
Fix sticky header in table built with mat elements

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -20,8 +20,8 @@ export function _tableVirtualScrollDirectiveStrategyFactory(tableDir: TableItemS
   return tableDir.scrollStrategy;
 }
 
-const stickyHeaderSelector = '.mat-header-row .mat-table-sticky';
-const stickyFooterSelector = '.mat-footer-row .mat-table-sticky';
+const stickyHeaderSelector = '.mat-header-row .mat-table-sticky, .mat-header-row.mat-table-sticky';
+const stickyFooterSelector = '.mat-footer-row .mat-table-sticky, .mat-header-row.mat-table-sticky';
 
 const defaults = {
   rowHeight: 48,


### PR DESCRIPTION
When a table is built using `mat-table` elements instead of directives, the `.mat-table-sticky` class is applied on the header row, not on the header cells.

This change will make the header stickiness behave correctly for both cases (elements and directives).