### PR TITLE
use "virtualScrollTable" instead of MatTable class for referencing th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ export class MyComponent {
 ```
 
 #### Directive
-The `tvsItemSize` directive makes the magic
+The `tvsItemSize` directive and `#virtualScrollTable` makes the magic
 
 ```html
 <cdk-virtual-scroll-viewport tvsItemSize="48" headerHeight="56" style="height: 400px;">
-    <table mat-table [dataSource]="dataSource">
+    <table mat-table #virtualScrollTable [dataSource]="dataSource">
     ...
     </table>
 </cdk-virtual-scroll-viewport>

--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -72,7 +72,7 @@ export class TableItemSizeDirective implements OnChanges, AfterContentInit, OnDe
   @Input()
   bufferMultiplier: string | number = defaults.bufferMultiplier;
 
-  @ContentChild(MatTable, { static: false })
+  @ContentChild('virtualScrollTable', { static: false })
   table: MatTable<any>;
 
   scrollStrategy = new FixedSizeTableVirtualScrollStrategy();


### PR DESCRIPTION
…e MatTable (and possibly now also MatLegacyTable) in ContentChild()

adding #virtualScrollTable was my workaround for now to make it work with Angualr Material 15 (at least for MatLegacyTable) as well as 14.

Referencing by MatTable does not work in Angular Material 15 with legacy components because their class names have changed. I wasnt't able to test compatiblity to the new MDC MatTable yet.