### PR TITLE
fix - updateChangeSubscription() : add override

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-data-source.ts
@@ -89,7 +89,7 @@ export class TableVirtualScrollDataSource<T> extends MatTableDataSource<T> imple
   public dataOfRange$: Subject<T[]>;
   private streamsReady: boolean;
 
-  _updateChangeSubscription() {
+  override _updateChangeSubscription() {
     this.initStreams();
     const _sort: MatSort | null = this['_sort'];
     const _paginator: MatPaginator | null = this['_paginator'];


### PR DESCRIPTION
Add the `override` to `_updateChangeSubscription()` since it extends to the `MatTableDataSource` class. 

`override` may be require in some typescript configuration and it should be declare here.