### PR TITLE
update table-item-size.directive.ts rowHeight

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts
@@ -45,7 +45,7 @@ function isCdkTable<T>(table: unknown): table is CdkTable<T> {
 }
 
 const defaults = {
-  rowHeight: 48,
+  rowHeight: 52,
   headerHeight: 56,
   headerEnabled: true,
   footerHeight: 48,


### PR DESCRIPTION
CHange the `defaults` `rowHeight` value from `48` to `52`.

`52` is now the new default, after the angular v15 migration

@See: https://material.angular.io/components/table/overview