### PR TITLE
Trigger stickyChange when attaching viewport

### DIFF
--- a/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/fixed-size-table-virtual-scroll-strategy.ts
@@ -40,6 +40,7 @@ export class FixedSizeTableVirtualScrollStrategy implements VirtualScrollStrateg
   public attach(viewport: CdkVirtualScrollViewport): void {
     this.viewport = viewport;
     this.viewport.renderedRangeStream.subscribe(this.renderedRangeStream);
+    this.stickyChange.next(0);
     this.onDataLengthChanged();
   }
 


### PR DESCRIPTION
- Fixes an issue in chromium browsers where: 
  - If the table has a sticky header and stickyPositions is not yet initialized 
  - And a scrollToIndex is issued to an index outside the current range 
  - The browser triggers a second scroll event when initializing the sticky elements, possibly messing up the scrolling and not showing the index issued to scrollToIndex

- Strangely, the line reading `offsetTop` in `initStickyPositions` seems to be what is triggering the unwanted scroll. Seems to be some browser specific behavior.

Might fix https://github.com/diprokon/ng-table-virtual-scroll/issues/126 . Confirmation needed.