### PR TITLE
Introduced new Input named visibleRowsCount, exposed Data property and changed Readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Virtual Scroll for Angular Material Table
+# Virtual Scroll for Angular CDK Table
 
 An Angular Directive, which allow to use [virtual scrolling](https://material.angular.io/cdk/scrolling) in [mat-table](https://material.angular.io/components/table)
+
+⚠️ This is a fork from https://github.com/diprokon/ng-table-virtual-scroll
+That implements the changes from https://github.com/rosostolato/ng-table-virtual-scroll
+making it compatible with Angular 15+ and Angular Material 15+
 
 [![Demo](https://img.shields.io/badge/demo-online-ed1c46.svg)](https://diprokon.github.io/ng-table-virtual-scroll)
 [![npm](https://img.shields.io/npm/v/ng-table-virtual-scroll.svg?maxAge=2592000?style=plastic)](https://www.npmjs.com/package/ng-table-virtual-scroll)
@@ -22,7 +26,7 @@ An Angular Directive, which allow to use [virtual scrolling](https://material.an
 **NPM**
 
 ```bash
-$ npm install -save ng-table-virtual-scroll
+$ npm install -save @dimkel/ng-cdk-table-virtual-scroll
 ```
 
 _**Version compatibility**_
@@ -41,7 +45,7 @@ _**Version compatibility**_
 ### Import `TableVirtualScrollModule`
 
 ```ts
-import { TableVirtualScrollModule } from 'ng-table-virtual-scroll';
+import { TableVirtualScrollModule } from '@dimkel/ng-cdk-table-virtual-scroll';
 
 @NgModule({
   imports: [
@@ -63,7 +67,7 @@ used as the data source for the `mat-table` (`CdkTableVirtualScrollDataSource` f
 **Note: without `TableVirtualScrollDataSource` the directive won't work**
 
 ```ts
-import { TableVirtualScrollDataSource } from 'ng-table-virtual-scroll';
+import { TableVirtualScrollDataSource } from '@dimkel/ng-cdk-table-virtual-scroll';
 
 @Component({...})
 export class MyComponent {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "ng-table-virtual-scroll",
-  "version": "1.6.1",
-  "description": "Virtual scroll for for Angular Material Table",
-  "homepage": "https://github.com/diprokon/ng-table-virtual-scroll",
+  "name": "@dimkel/ng-cdk-table-virtual-scroll",
+  "version": "1.0.4",
+  "description": "Virtual scroll for for Angular Cdk Table",
+  "homepage": "https://github.com/kelekd/ng-table-virtual-scroll",
   "author": {
     "name": "Dmytro Prokhorov",
     "url": "https://github.com/diprokon"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/diprokon/ng-table-virtual-scroll.git"
+    "url": "git://github.com/kelekd/ng-table-virtual-scroll.git"
   },
   "bugs": {
-    "url": "https://github.com/diprokon/ng-table-virtual-scroll/issues"
+    "url": "https://github.com/kelekd/ng-table-virtual-scroll/issues"
   },
   "keywords": [
     "angular",
@@ -35,7 +35,7 @@
     "e2e": "cypress open --component -b chrome",
     "e2e:ci": "cypress run --component --config-file cypress.config.ts"
   },
-  "private": true,
+  "private": false,
   "dependencies": {
     "@angular/animations": "^15.1.4",
     "@angular/cdk": "^15.1.4",

--- a/projects/ng-table-virtual-scroll/package.json
+++ b/projects/ng-table-virtual-scroll/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "ng-table-virtual-scroll",
-  "version": "1.6.1",
-  "description": "Virtual scroll for for Angular Material Table",
-  "homepage": "https://github.com/diprokon/ng-table-virtual-scroll",
+  "name": "@dimkel/ng-cdk-table-virtual-scroll",
+  "version": "1.0.4",
+  "description": "Virtual scroll for for Angular Cdk Table",
+  "homepage": "https://github.com/kelekd/ng-table-virtual-scroll",
   "author": {
     "name": "Dmytro Prokhorov",
     "url": "https://github.com/diprokon"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/diprokon/ng-table-virtual-scroll.git"
+    "url": "git://github.com/kelekd/ng-table-virtual-scroll.git"
   },
   "bugs": {
-    "url": "https://github.com/diprokon/ng-table-virtual-scroll/issues"
+    "url": "https://github.com/kelekd/ng-table-virtual-scroll/issues"
   },
   "keywords": [
     "angular",

--- a/projects/ng-table-virtual-scroll/src/lib/table-virtual-scroll.module.ts
+++ b/projects/ng-table-virtual-scroll/src/lib/table-virtual-scroll.module.ts
@@ -3,7 +3,9 @@ import { TableItemSizeDirective } from './table-item-size.directive';
 
 
 @NgModule({
-  declarations: [TableItemSizeDirective],
+  declarations: [
+    TableItemSizeDirective,
+  ],
   imports: [],
   exports: [TableItemSizeDirective]
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,11 @@
       "dom"
     ],
     "paths": {
-      "ng-table-virtual-scroll": [
+      "@dimkel/ng-cdk-table-virtual-scroll": [
         "projects/ng-table-virtual-scroll/src/public-api.ts"
+      ],
+      "ng-table-virtual-scroll": [
+        "projects/ng-table-virtual-scroll/src/public-api.ts",
       ]
     },
     "useDefineForClassFields": false


### PR DESCRIPTION
This pull request includes several changes to update the library to be compatible with Angular 15+ and Angular Material 15+. The changes involve renaming the package, updating import paths, and simplifying the codebase by removing dependencies on Angular Material components.

### Package Renaming and Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R8): Updated the package name and added a note about the fork and compatibility with Angular 15+ and Angular Material 15+ [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R29) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R48) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R70).
* `package.json` and `projects/ng-table-virtual-scroll/package.json`: Changed the package name to `@dimkel/ng-cdk-table-virtual-scroll`, updated version, description, homepage, repository URL, and made the package public [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R15) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L38-R38) [[3]](diffhunk://#diff-28234042ebac4ce5b287a9dd95668ba05d6864dc351a969d19906c3ec99860eeL2-R15).

### Codebase Simplification:
* [`projects/ng-table-virtual-scroll/src/lib/table-data-source.ts`](diffhunk://#diff-07a0afa148efd1f0a21a4b8774ddb3a1488d555f13db223fa6170dc3ac70c5d1L1-R1): Removed dependencies on Angular Material components (`MatTableDataSource`, `MatSort`, `MatPaginator`) and refactored `TableVirtualScrollDataSource` to extend `DataSource` from Angular CDK [[1]](diffhunk://#diff-07a0afa148efd1f0a21a4b8774ddb3a1488d555f13db223fa6170dc3ac70c5d1L1-R1) [[2]](diffhunk://#diff-07a0afa148efd1f0a21a4b8774ddb3a1488d555f13db223fa6170dc3ac70c5d1L87-R118).

### Directive Updates:
* [`projects/ng-table-virtual-scroll/src/lib/table-item-size.directive.ts`](diffhunk://#diff-12109ac984ba35e9cf73df54bd00f2887065a3a201836e931efb90dd69b4dd5fL13-R16): Removed checks for `MatTable` and `CdkTableVirtualScrollDataSource`, added `visibleRowsCount` input, and updated the directive to work with the simplified `TableVirtualScrollDataSource` [[1]](diffhunk://#diff-12109ac984ba35e9cf73df54bd00f2887065a3a201836e931efb90dd69b4dd5fL13-R16) [[2]](diffhunk://#diff-12109ac984ba35e9cf73df54bd00f2887065a3a201836e931efb90dd69b4dd5fL39-L46) [[3]](diffhunk://#diff-12109ac984ba35e9cf73df54bd00f2887065a3a201836e931efb90dd69b4dd5fR77-R79) [[4]](diffhunk://#diff-12109ac984ba35e9cf73df54bd00f2887065a3a201836e931efb90dd69b4dd5fL155-R183).

### Module Declaration:
* [`projects/ng-table-virtual-scroll/src/lib/table-virtual-scroll.module.ts`](diffhunk://#diff-cc51d0b55557fee174e9334430aba86c9940f039c15dd0fc03fc6722ecefb8c6L6-R8): Updated the module to declare the `TableItemSizeDirective`.